### PR TITLE
[Feat] 카카오 소셜 로그인 및 JWT 토큰 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	testImplementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.6'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/tave/weathertago/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/tave/weathertago/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 로그인 에러
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4012", "토큰이 만료되었습니다."),
+
+    // 사용자 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041", "사용자를 찾을 수 없습니다."),
 
     // 역 관려 에러
     STATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "STATION4001", "해당 stationId에 대한 역을 찾을 수 없습니다.");

--- a/src/main/java/com/tave/weathertago/apiPayload/exception/handler/UserHandler.java
+++ b/src/main/java/com/tave/weathertago/apiPayload/exception/handler/UserHandler.java
@@ -1,0 +1,11 @@
+package com.tave.weathertago.apiPayload.exception.handler;
+
+import com.tave.weathertago.apiPayload.code.BaseErrorCode;
+import com.tave.weathertago.apiPayload.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+
+    public UserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/SecurityConfig.java
+++ b/src/main/java/com/tave/weathertago/config/security/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.tave.weathertago.config.security;
+
+import com.tave.weathertago.config.security.jwt.JwtAuthenticationFilter;
+import com.tave.weathertago.config.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+
+                    // 🔓 [개발 단계] 전체 API 허용 (Swagger 포함)
+                    .anyRequest().permitAll()
+
+                    /*
+                    // 🔒 [배포 단계] 인증 적용 설정 (필요한 경로만 허용)
+                    .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .anyRequest().authenticated()
+                     */
+
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.tave.weathertago.config.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException, ServletException {
+
+        // 401 Unauthorized 응답
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("isSuccess", false);
+        responseBody.put("code", "COMMON401");
+        responseBody.put("message", "인증되지 않은 사용자입니다.");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getOutputStream(), responseBody);
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.tave.weathertago.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 요청에서 토큰 추출
+        String token = jwtTokenProvider.resolveToken(request);
+
+        // 유효한 토큰이면 인증 객체 생성 후 SecurityContext에 저장
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,105 @@
+package com.tave.weathertago.config.security.jwt;
+
+import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
+import com.tave.weathertago.apiPayload.exception.handler.UserHandler;
+import com.tave.weathertago.config.security.properties.Constants;
+import com.tave.weathertago.config.security.properties.JwtProperties;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    // 시크릿 키 바이트 배열로 변환
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    // 사용자 kakaoId를 token 생성
+    public String generateAccessToken(String kakaoId) {
+        return Jwts.builder()
+                .setSubject(kakaoId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String kakaoId) {
+        return Jwts.builder()
+                .setSubject(kakaoId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getRefresh()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // jwt 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new UserHandler(ErrorStatus.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    // jwt에서 kakao id 꺼내기 -> sub에 저장
+    public String getKakaoId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getSubject();
+    }
+
+    // Request 헤더에서 순수 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+
+    // jwt로부터 Spring Security 인증 객체 생성
+    public Authentication getAuthentication(String token) {
+        String kakaoId = getKakaoId(token);
+        User principal = new User(kakaoId, "", Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+    }
+
+    // 인증 객체 추출 (Spring Security의 Authentication 객체 생성)
+    public Authentication extractAuthentication(HttpServletRequest request) {
+        String token = resolveToken(request);
+        if (token == null || !validateToken(token)) {
+            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        String kakaoId = getKakaoId(token);
+        User principal = new User(kakaoId, "", Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/properties/Constants.java
+++ b/src/main/java/com/tave/weathertago/config/security/properties/Constants.java
@@ -1,0 +1,6 @@
+package com.tave.weathertago.config.security.properties;
+
+public final class Constants {
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+}

--- a/src/main/java/com/tave/weathertago/config/security/properties/JwtProperties.java
+++ b/src/main/java/com/tave/weathertago/config/security/properties/JwtProperties.java
@@ -1,0 +1,22 @@
+package com.tave.weathertago.config.security.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt.token")
+public class JwtProperties {
+    private String secretKey = "";
+    private Expiration expiration;
+
+    @Getter
+    @Setter
+    public static class Expiration {
+        private Long access;
+        private Long refresh;
+    }
+}

--- a/src/main/java/com/tave/weathertago/controller/AuthController.java
+++ b/src/main/java/com/tave/weathertago/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.tave.weathertago.controller;
+
+import com.tave.weathertago.apiPayload.ApiResponse;
+import com.tave.weathertago.dto.Auth.AuthRequestDTO;
+import com.tave.weathertago.dto.Auth.AuthResponseDTO;
+import com.tave.weathertago.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "카카오 소셜 로그인 및 JWT 토큰 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    @Operation(summary = "카카오 로그인", description = "카카오 accessToken으로 로그인/회원가입을 처리하고 JWT를 발급합니다.")
+    public ApiResponse<AuthResponseDTO.LoginResultDTO> login(@RequestBody @Valid AuthRequestDTO.KakaoLoginRequest request) {
+        return ApiResponse.onSuccess(authService.kakaoLogin(request.getAccessToken()));
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "refreshToken으로 accessToken을 재발급합니다.")
+    public ApiResponse<AuthResponseDTO.ReissueResultDTO> reissue(@RequestBody @Valid AuthRequestDTO.ReissueRequest request) {
+        return ApiResponse.onSuccess(authService.reissueToken(request));
+    }
+}

--- a/src/main/java/com/tave/weathertago/converter/AuthConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/AuthConverter.java
@@ -1,0 +1,21 @@
+package com.tave.weathertago.converter;
+
+import com.tave.weathertago.dto.Auth.AuthResponseDTO;
+
+public class AuthConverter {
+
+    public static AuthResponseDTO.LoginResultDTO toLoginResultDTO(Long userId, String accessToken, String refreshToken, boolean isNewUser) {
+        return AuthResponseDTO.LoginResultDTO.builder()
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewUser(isNewUser)
+                .build();
+    }
+
+    public static AuthResponseDTO.ReissueResultDTO toReissueResultDTO(String newAccessToken) {
+        return AuthResponseDTO.ReissueResultDTO.builder()
+                .accessToken(newAccessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/tave/weathertago/domain/User.java
+++ b/src/main/java/com/tave/weathertago/domain/User.java
@@ -1,0 +1,33 @@
+package com.tave.weathertago.domain;
+
+import com.tave.weathertago.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String kakaoId;
+
+    @Column(nullable = false, length = 255)
+    private String nickname;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Column(length = 500)
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/tave/weathertago/dto/Auth/AuthRequestDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/Auth/AuthRequestDTO.java
@@ -1,0 +1,19 @@
+package com.tave.weathertago.dto.Auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class AuthRequestDTO {
+
+    @Getter
+    public static class KakaoLoginRequest {
+        @NotBlank
+        private String accessToken;
+    }
+
+    @Getter
+    public static class ReissueRequest {
+        @NotBlank
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/tave/weathertago/dto/Auth/AuthResponseDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/Auth/AuthResponseDTO.java
@@ -1,0 +1,22 @@
+package com.tave.weathertago.dto.Auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthResponseDTO {
+
+    @Getter
+    @Builder
+    public static class LoginResultDTO {
+        private Long userId;
+        private String accessToken;
+        private String refreshToken;
+        private boolean isNewUser;
+    }
+
+    @Getter
+    @Builder
+    public static class ReissueResultDTO {
+        private String accessToken;
+    }
+}

--- a/src/main/java/com/tave/weathertago/dto/Auth/KakaoUserInfo.java
+++ b/src/main/java/com/tave/weathertago/dto/Auth/KakaoUserInfo.java
@@ -1,0 +1,37 @@
+package com.tave.weathertago.dto.Auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+    @JsonProperty("id")
+    private String kakaoId;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    public String getNickname() {
+        return kakaoAccount.getProfile().getNickname();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Profile {
+            private String nickname;
+        }
+    }
+}

--- a/src/main/java/com/tave/weathertago/infrastructure/KakaoApiClient.java
+++ b/src/main/java/com/tave/weathertago/infrastructure/KakaoApiClient.java
@@ -1,0 +1,45 @@
+package com.tave.weathertago.infrastructure;
+
+import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
+import com.tave.weathertago.apiPayload.exception.GeneralException;
+import com.tave.weathertago.dto.Auth.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        // 1. Authorization 헤더 구성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 2. 요청 객체 생성
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        // 3. 요청 전송
+        try {
+            ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
+                    KAKAO_USER_INFO_URL,
+                    HttpMethod.GET,
+                    entity,
+                    KakaoUserInfo.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException.Unauthorized e) {
+            // Kakao access token이 유효하지 않을 때
+            throw new GeneralException(ErrorStatus.INVALID_TOKEN);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/tave/weathertago/repository/UserRepository.java
+++ b/src/main/java/com/tave/weathertago/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.tave.weathertago.repository;
+
+import com.tave.weathertago.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/tave/weathertago/service/auth/AuthService.java
+++ b/src/main/java/com/tave/weathertago/service/auth/AuthService.java
@@ -1,0 +1,9 @@
+package com.tave.weathertago.service.auth;
+
+import com.tave.weathertago.dto.Auth.AuthRequestDTO;
+import com.tave.weathertago.dto.Auth.AuthResponseDTO;
+
+public interface AuthService {
+    AuthResponseDTO.LoginResultDTO kakaoLogin(String kakaoAccessToken);
+    AuthResponseDTO.ReissueResultDTO reissueToken(AuthRequestDTO.ReissueRequest request);
+}

--- a/src/main/java/com/tave/weathertago/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/auth/AuthServiceImpl.java
@@ -1,0 +1,72 @@
+package com.tave.weathertago.service.auth;
+
+import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
+import com.tave.weathertago.apiPayload.exception.handler.UserHandler;
+import com.tave.weathertago.config.security.jwt.JwtTokenProvider;
+import com.tave.weathertago.converter.AuthConverter;
+import com.tave.weathertago.domain.User;
+import com.tave.weathertago.dto.Auth.AuthRequestDTO;
+import com.tave.weathertago.dto.Auth.AuthResponseDTO;
+import com.tave.weathertago.dto.Auth.KakaoUserInfo;
+import com.tave.weathertago.infrastructure.KakaoApiClient;
+import com.tave.weathertago.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final KakaoApiClient kakaoApiClient;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    @Transactional
+    public AuthResponseDTO.LoginResultDTO kakaoLogin(String accessToken) {
+
+        // 1. 카카오 사용자 정보 조회
+        KakaoUserInfo kakaoUserInfo = kakaoApiClient.getUserInfo(accessToken);
+
+        // 2. 사용자 정보로 회원 존재 여부 확인
+        User user = findOrCreateUser(kakaoUserInfo);
+        boolean isNewUser = user.getCreatedAt().equals(user.getUpdatedAt());
+
+        // 3. JWT 발급
+        String accessJwt = jwtTokenProvider.generateAccessToken(user.getKakaoId());
+        String refreshJwt = jwtTokenProvider.generateRefreshToken(user.getKakaoId());
+        user.updateRefreshToken(refreshJwt);
+
+        // 4. 응답 생성
+        return AuthConverter.toLoginResultDTO(user.getId(), accessJwt, refreshJwt, isNewUser);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuthResponseDTO.ReissueResultDTO reissueToken(AuthRequestDTO.ReissueRequest request) {
+        jwtTokenProvider.validateToken(request.getRefreshToken());
+
+        String kakaoId = jwtTokenProvider.getKakaoId(request.getRefreshToken());
+
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (!user.getRefreshToken().equals(request.getRefreshToken())) {
+            throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+        }
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getKakaoId());
+
+        return AuthConverter.toReissueResultDTO(newAccessToken);
+    }
+
+    private User findOrCreateUser(KakaoUserInfo kakaoUserInfo) {
+        return userRepository.findByKakaoId(kakaoUserInfo.getKakaoId())
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .kakaoId(kakaoUserInfo.getKakaoId())
+                        .email(kakaoUserInfo.getEmail())
+                        .nickname(kakaoUserInfo.getNickname())
+                        .build()));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 프론트엔드에서 전달받은 카카오 accessToken을 기반으로 사용자를 로그인 & 최초 로그인 시 회원가입 처리까지 수행합니다.
> 카카오에서 받아온 사용자의 닉네임, 이메일과 발급한 refreshToken을 User 테이블에 저장합니다.
> refreshToken으로 새로운 accessToken을 재발급합니다.
> 토큰 서브젝트(sub)로는 kakaoId를 사용합니다.

> `application.yml`, `build.gradle` 변경 사항 확인해주세요!