### PR TITLE
[Fix] 크롤링 기능 보완 및 entitiy 수정

### DIFF
--- a/src/main/java/com/tave/weathertago/controller/Notice/NoticeRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/Notice/NoticeRestController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 @Tag(name = "notice", description = "공지사항 조회 API")
 @RestController
@@ -24,7 +25,7 @@ public class NoticeRestController {
 
     private final NoticeQueryService noticeQueryService;
 
-    @Operation(summary = "공지사항 전체 조회", description = "DB에 저장된 모든 공지사항을 조회합니다.")
+    @Operation(summary = "공지사항 전체 조회", description = "DB에 저장된 모든 공지사항을 최신순으로 조회합니다.")
     @GetMapping("")
     public ApiResponse<List<NoticeResponseDTO.NoticeDetail>> getNotices() {
         List<Notice> notices=noticeQueryService.getAllNotices();
@@ -37,8 +38,8 @@ public class NoticeRestController {
     @Operation(summary = "특정 공지사항 조회", description = "특정 공지사항을 id로 조회합니다.")
     @GetMapping("/{noticeId}")
     public ApiResponse<NoticeResponseDTO.NoticeDetail> getNotice(@PathVariable("noticeId") Long noticeId) {
-        Notice notice = noticeQueryService.getNoticesByNoticeId(noticeId);
-        NoticeResponseDTO.NoticeDetail noticeDetail = NoticeConverter.toNoticeDetail(notice);
+        Optional<Notice> notice = noticeQueryService.getNoticesByNoticeId(noticeId);
+        NoticeResponseDTO.NoticeDetail noticeDetail = NoticeConverter.toNoticeDetail(notice.orElse(null));
         return ApiResponse.onSuccess(noticeDetail);
     }
 }

--- a/src/main/java/com/tave/weathertago/converter/NoticeConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/NoticeConverter.java
@@ -12,7 +12,8 @@ public class NoticeConverter {
                 .noticeId(notice.getNoticeId())
                 .title(notice.getTitle())
                 .content(notice.getContent())
-                .createdAt(LocalDateTime.now())
+                .createdAt(notice.getCreateAt())
+                .updatedAt(notice.getUpdateAt())
                 .build();
 
     }

--- a/src/main/java/com/tave/weathertago/domain/Notice.java
+++ b/src/main/java/com/tave/weathertago/domain/Notice.java
@@ -1,6 +1,5 @@
 package com.tave.weathertago.domain;
 
-import com.tave.weathertago.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -11,14 +10,19 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Notice extends BaseEntity {
+public class Notice {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private Long noticeId;
 
     private String title;
 
     @Lob
     private String content;
+
+    // 크롤링할 데이터가 등록되었던 시간을 저장하는 것이라 baseEntity 사용 X
+    private String createAt;
+
+    private String updateAt;
 
 }

--- a/src/main/java/com/tave/weathertago/dto/Notice/NoticeResponseDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/Notice/NoticeResponseDTO.java
@@ -15,7 +15,8 @@ public class NoticeResponseDTO {
         Long noticeId;
         String title;
         String content;
-        LocalDateTime createdAt;
+        String createdAt;
+        String updatedAt;
     }
 
 }

--- a/src/main/java/com/tave/weathertago/repository/NoticeRepository.java
+++ b/src/main/java/com/tave/weathertago/repository/NoticeRepository.java
@@ -3,9 +3,13 @@ package com.tave.weathertago.repository;
 import com.tave.weathertago.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // id으로 Notice 리스트 조회
-    Notice findByNoticeId(Long noticeId);
+    Optional<Notice> findByNoticeId(Long noticeId);
 
-    boolean existsByTitle(String title); // 제목 필드명이 title일 때
+    List<Notice> findAllByOrderByNoticeIdDesc(); // id 내림차순으로 정렬 (최신 공지사항부터)
+
 }

--- a/src/main/java/com/tave/weathertago/service/Notice/NoticeQueryService.java
+++ b/src/main/java/com/tave/weathertago/service/Notice/NoticeQueryService.java
@@ -3,10 +3,11 @@ package com.tave.weathertago.service.Notice;
 import com.tave.weathertago.domain.Notice;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoticeQueryService {
 
-    Notice getNoticesByNoticeId(Long noticeId);
+    Optional<Notice> getNoticesByNoticeId(Long noticeId);
 
     List<Notice> getAllNotices();
 

--- a/src/main/java/com/tave/weathertago/service/Notice/NoticeQueryServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/Notice/NoticeQueryServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +15,10 @@ public class NoticeQueryServiceImpl implements NoticeQueryService {
     private final NoticeRepository noticeRepository;
 
     @Override
-    public Notice getNoticesByNoticeId(Long noticeId) { return noticeRepository.findByNoticeId(noticeId); }
+    public Optional<Notice> getNoticesByNoticeId(Long noticeId) { return noticeRepository.findByNoticeId(noticeId); }
 
     @Override
-    public List<Notice> getAllNotices() { return noticeRepository.findAll();
+    public List<Notice> getAllNotices() { return noticeRepository.findAllByOrderByNoticeIdDesc();
 
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 9

## 📝작업 내용

1. 크롤링 아이디 큰 순서대로 조회되도록 (최신 순으로 조회)
2. 중복되는 공지사항을 아이디로 확인
3. updateAt, createAt 따로 생성 (우리가 생성하고 업데이트한 시간이 아닌, 크롤링 데이터가 웹사이트에 등록되고 업데이트된 시간으로 변경 -> BaseEntity 사용 X)
4. 해당 아이디가 DB에 없으면 공지사항 생성하도록, DB에 저장된 updateAt과 다르면 업데이트하도록
5. 공지사항 내용을 제목 API에서 가져오도록 수정
