### PR TITLE
[Fix] JWT 에러 핸들링 설정 및 refresh token 일회용으로 변경

### DIFF
--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.tave.weathertago.config.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,14 +23,15 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException)
             throws IOException, ServletException {
 
-        // 401 Unauthorized 응답
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        ErrorStatus errorStatus = ErrorStatus.INVALID_TOKEN;
+
+        response.setStatus(errorStatus.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("isSuccess", false);
-        responseBody.put("code", "COMMON401");
-        responseBody.put("message", "인증되지 않은 사용자입니다.");
+        responseBody.put("code", errorStatus.getCode());
+        responseBody.put("message", errorStatus.getMessage());
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.writeValue(response.getOutputStream(), responseBody);

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -22,16 +23,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 요청에서 토큰 추출
-        String token = jwtTokenProvider.resolveToken(request);
+        try {
+            // 요청에서 토큰 추출
+            String token = jwtTokenProvider.resolveToken(request);
 
-        // 유효한 토큰이면 인증 객체 생성 후 SecurityContext에 저장
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            // 유효한 토큰이면 인증 객체 생성 후 SecurityContext에 저장
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            // 다음 필터로 넘김
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            throw new AuthenticationServiceException("JWT 인증 실패: " + e.getMessage(), e);
         }
-
-        // 다음 필터로 넘김
-        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.tave.weathertago.config.security.jwt;
 
 import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
-import com.tave.weathertago.apiPayload.exception.handler.UserHandler;
+import com.tave.weathertago.apiPayload.exception.GeneralException;
 import com.tave.weathertago.config.security.properties.Constants;
 import com.tave.weathertago.config.security.properties.JwtProperties;
 import io.jsonwebtoken.*;
@@ -57,9 +57,9 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
-            throw new UserHandler(ErrorStatus.EXPIRED_TOKEN);
+            throw new GeneralException(ErrorStatus.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+            throw new GeneralException(ErrorStatus.INVALID_TOKEN);
         }
     }
 
@@ -95,7 +95,7 @@ public class JwtTokenProvider {
     public Authentication extractAuthentication(HttpServletRequest request) {
         String token = resolveToken(request);
         if (token == null || !validateToken(token)) {
-            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
         }
 
         String kakaoId = getKakaoId(token);

--- a/src/main/java/com/tave/weathertago/converter/AuthConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/AuthConverter.java
@@ -13,9 +13,10 @@ public class AuthConverter {
                 .build();
     }
 
-    public static AuthResponseDTO.ReissueResultDTO toReissueResultDTO(String newAccessToken) {
+    public static AuthResponseDTO.ReissueResultDTO toReissueResultDTO(String newAccessToken, String newRefreshToken) {
         return AuthResponseDTO.ReissueResultDTO.builder()
                 .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/tave/weathertago/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/auth/AuthServiceImpl.java
@@ -43,8 +43,9 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public AuthResponseDTO.ReissueResultDTO reissueToken(AuthRequestDTO.ReissueRequest request) {
+
         jwtTokenProvider.validateToken(request.getRefreshToken());
 
         String kakaoId = jwtTokenProvider.getKakaoId(request.getRefreshToken());
@@ -57,8 +58,11 @@ public class AuthServiceImpl implements AuthService {
         }
 
         String newAccessToken = jwtTokenProvider.generateAccessToken(user.getKakaoId());
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(kakaoId);
 
-        return AuthConverter.toReissueResultDTO(newAccessToken);
+        user.updateRefreshToken(newRefreshToken);
+
+        return AuthConverter.toReissueResultDTO(newAccessToken, newRefreshToken);
     }
 
     private User findOrCreateUser(KakaoUserInfo kakaoUserInfo) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #15

## 📝작업 내용

> RefreshToken 재발급 보안 강화
>  - RefreshToken 재발급 시 **기존 토큰을 무효화**하고 새로운 RefreshToken을 함께 재발급
>  - 동일한 RefreshToken의 반복 사용 방지 (1회용 방식 적용)

> 인증 실패 응답 형식 개선
>  - 유효하지 않은 토큰 등 인증 예외 발생 시 `JwtAuthenticationEntryPoint`에서 JSON 형식으로 일관된 응답 반환
>  - `ErrorStatus.INVALID_TOKEN` 기반으로 응답 구성