### PR TITLE
fix: workflow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,6 @@ services:
       - "8080:8080"
 #    env_file:
 #      - .env
-    depends_on:
-      - redis
     networks:
       - weathertago-network
     restart: always # 컨테이너가 종료되면 항상 재시작


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * docker-compose 설정에서 `weathertago-app` 서비스의 `redis` 서비스에 대한 의존성(`depends_on`)이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->