### PR TITLE
[Feat]106-modify-cratedAt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	testImplementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.6'
 
+
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/tave/weathertago/config/JacksonConfig.java
+++ b/src/main/java/com/tave/weathertago/config/JacksonConfig.java
@@ -1,20 +1,22 @@
 package com.tave.weathertago.config;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import java.util.TimeZone;
 
 @Configuration
 public class JacksonConfig {
+
     @Bean
-    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
-        return builder -> {
-            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            builder.simpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            builder.timeZone(TimeZone.getTimeZone("Asia/Seoul"));
-        };
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // ✅ LocalDateTime 모듈 등록
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ✅ 문자열로 직렬화
+        mapper.setTimeZone(TimeZone.getTimeZone("Asia/Seoul")); // ✅ 타임존 설정
+        return mapper;
     }
 }

--- a/src/main/java/com/tave/weathertago/config/SwaggerConfig.java
+++ b/src/main/java/com/tave/weathertago/config/SwaggerConfig.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {

--- a/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
@@ -7,12 +7,15 @@ import com.tave.weathertago.infrastructure.csv.StationCsvImporter;
 import com.tave.weathertago.service.station.StationQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/tave/weathertago/dto/station/StationResponseDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/station/StationResponseDTO.java
@@ -1,7 +1,9 @@
 package com.tave.weathertago.dto.station;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tave.weathertago.dto.CongestionDTO;
 import com.tave.weathertago.dto.weather.WeatherResponseDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +23,8 @@ public class StationResponseDTO {
         String stationCode;
         WeatherResponseDTO weather;
         CongestionDTO congestion;
+        @Schema(type = "string", format = "date-time", example = "2025-07-08T22:40:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         LocalDateTime createdAt;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#106

## 📝작업 내용

createdAt 응답 형식 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * API 응답의 날짜/시간 필드가 ISO-8601 형식(예: yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul 타임존)으로 표시됩니다.
  * API 문서에 날짜/시간 필드의 예시와 포맷 정보가 추가되었습니다.

* **리팩터링**
  * JSON 직렬화 설정 방식이 개선되어 날짜/시간 데이터가 일관되게 처리됩니다.

* **문서화**
  * API 문서의 날짜/시간 필드 설명이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->