### PR TITLE
fix: ai 서버에 요청 보낼 때 "호선" 제거

### DIFF
--- a/src/main/java/com/tave/weathertago/converter/PredictionConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/PredictionConverter.java
@@ -16,7 +16,7 @@ public class PredictionConverter {
 
     public static PredictionRequestDTO toPredictionRequest(Station station, int direction, LocalDateTime datetime, WeatherResponseDTO weather) {
         return PredictionRequestDTO.builder()
-                .line(station.getLine())
+                .line(station.getLine().replace("호선", ""))
                 .station_name(station.getName())
                 .datetime(datetime.format(DATETIME_FMT))
                 .direction(direction)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62

## 📝작업 내용

> AI 서버에 int로 보내기 위해 "호선" 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예측 요청 시 역 노선명에서 "호선" 문자열이 제거되어 보다 정확한 정보가 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->