### PR TITLE
[Feat] 특정 시간 범위 혼잡도를 모두 불러오는 테스트 api 추가

### DIFF
--- a/src/main/java/com/tave/weathertago/controller/CongestionTestController.java
+++ b/src/main/java/com/tave/weathertago/controller/CongestionTestController.java
@@ -47,11 +47,13 @@ public class CongestionTestController {
     @GetMapping("/range")
     public ApiResponse<List<PredictionResponseDTO>> getCongestionRange(
             @RequestParam Long stationId,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDateTime
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDateTime,
+            @RequestParam int startHour,
+            @RequestParam int endHour
     ) {
         List<PredictionResponseDTO> results = new ArrayList<>();
 
-        for (int hour = 1; hour <= 9; hour++) {
+        for (int hour = startHour; hour <= endHour; hour++) {
             LocalDateTime datetime = baseDateTime.withHour(hour).withMinute(0).withSecond(0).withNano(0);
             PredictionResponseDTO result = congestionQueryService.getCongestion(stationId, datetime);
             results.add(result);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> 여러 시간대의 혼잡도를 불러올 수 있는지 테스트용 (삭제 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 혼잡도 범위 조회 API에서 시작 시간과 종료 시간을 직접 지정할 수 있도록 기능이 추가되었습니다.  
  * 사용자가 원하는 시간 범위에 대한 혼잡도 데이터를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->