### PR TITLE
fix: 시간대

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM openjdk:17-jdk-slim
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && echo "Asia/Seoul" > /etc/timezone
 ARG JAR_FILE=build/libs/backend-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ networks:
 services:
   weathertago-app:
     image: ysjjw2003/weathertago:${TAG}
+    environment:
+      - TZ=Asia/Seoul
     container_name: weathertago-app
     ports: # 외부까지 연결 / expose : 컨테이너끼리만 연결
       - "8080:8080"

--- a/src/main/java/com/tave/weathertago/service/alarm/AlarmSendServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/alarm/AlarmSendServiceImpl.java
@@ -69,6 +69,8 @@ public class AlarmSendServiceImpl implements AlarmSendService {
             default -> throw new AlarmHandler(ErrorStatus.ALARM_INVALID_INPUT);
         }
 
+        log.info(String.valueOf(refDateTime));
+
 
         // 3. 혼잡도·날씨 정보 조회
         PredictionWithWeatherResponseDTO result = congestionQueryService.getCongestionWithWeather(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 컨테이너 및 서비스의 기본 시간대를 "Asia/Seoul"로 설정하여 일관된 시간 환경을 제공합니다.

* **New Features**
  * 알람 서비스에서 기준 날짜 및 시간이 로그로 기록되어 동작 확인이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->