### PR TITLE
[Fix] refresh token 관리 방식 redis로 변경

### DIFF
--- a/src/main/java/com/tave/weathertago/apiPayload/exception/handler/AuthHandler.java
+++ b/src/main/java/com/tave/weathertago/apiPayload/exception/handler/AuthHandler.java
@@ -1,0 +1,11 @@
+package com.tave.weathertago.apiPayload.exception.handler;
+
+import com.tave.weathertago.apiPayload.code.BaseErrorCode;
+import com.tave.weathertago.apiPayload.exception.GeneralException;
+
+public class AuthHandler extends GeneralException {
+
+    public AuthHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
@@ -106,4 +106,9 @@ public class JwtTokenProvider {
         User principal = new User(kakaoId, "", Collections.emptyList());
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }
+
+    // refresh token 만료 시간 반환
+    public long getRefreshTokenExpiration() {
+        return jwtProperties.getExpiration().getRefresh();
+    }
 }

--- a/src/main/java/com/tave/weathertago/domain/User.java
+++ b/src/main/java/com/tave/weathertago/domain/User.java
@@ -23,11 +23,4 @@ public class User extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String email;
-
-    @Column(length = 500)
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> mysql db에서 관리하던 refresh token을 redis에서 관리하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 오류 발생 시 보다 구체적인 예외 처리가 도입되었습니다.

* **버그 수정**
  * 리프레시 토큰이 더 이상 사용자 정보에 저장되지 않고, Redis를 통해 안전하게 관리됩니다.
  * 토큰 재발급 과정에서 유효하지 않은 리프레시 토큰에 대한 검증 및 오류 처리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->