### PR TITLE
[Feat] 지하철 역 3일치 시간대별 날씨, 혼잡도 조회 API 구현

### DIFF
--- a/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
@@ -5,6 +5,8 @@ import com.tave.weathertago.apiPayload.ApiResponse;
 import com.tave.weathertago.dto.station.StationResponseDTO;
 import com.tave.weathertago.infrastructure.csv.StationCsvImporter;
 import com.tave.weathertago.service.station.StationQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -74,6 +76,20 @@ public class StationRestController {
     public ApiResponse<List<StationResponseDTO.StationInfoDTO>> getAllStationsInfo() {
         List<StationResponseDTO.StationInfoDTO> result = stationQueryService.getAllStationsInfo();
         return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "지하철 역 시간대별 상태 조회", description = "지정된 기준 시각부터 3일 뒤 00시까지의 날씨와 혼잡도 정보를 시간대별로 조회합니다.")
+    @GetMapping("/status")
+    public ApiResponse<StationResponseDTO.StationStatusResponseDTO> getStatus(
+            @Parameter(description = "조회할 역의 ID")
+            @RequestParam("stationId") Long stationId,
+
+            @Parameter(description = "기준 시각 (yyyy-MM-ddTHH:mm:ss)")
+            @RequestParam("baseDatetime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDatetime
+    ) {
+        return ApiResponse.onSuccess(
+                stationQueryService.getStatus(stationId, baseDatetime)
+        );
     }
 
 }

--- a/src/main/java/com/tave/weathertago/converter/StationConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/StationConverter.java
@@ -6,6 +6,7 @@ import com.tave.weathertago.dto.station.StationResponseDTO;
 import com.tave.weathertago.dto.weather.WeatherResponseDTO;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 public class StationConverter {
@@ -46,6 +47,16 @@ public class StationConverter {
                 .stationLine(station.getLine())
                 .phoneNumber(station.getPhoneNumber())
                 .address(station.getAddress())
+                .build();
+    }
+
+    public static StationResponseDTO.StationStatusResponseDTO toStatusResponse(
+            List<StationResponseDTO.StationStatusResponseDTO.TimedWeatherDTO> weathers,
+            List<StationResponseDTO.StationStatusResponseDTO.TimedCongestionDTO> congestions
+    ) {
+        return StationResponseDTO.StationStatusResponseDTO.builder()
+                .weathers(weathers)
+                .congestions(congestions)
                 .build();
     }
 

--- a/src/main/java/com/tave/weathertago/dto/station/StationResponseDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/station/StationResponseDTO.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 public class StationResponseDTO {
@@ -54,5 +55,26 @@ public class StationResponseDTO {
         private String stationLine;
         private String phoneNumber;
         private String address;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class StationStatusResponseDTO {
+        private List<TimedWeatherDTO> weathers;
+        private List<TimedCongestionDTO> congestions;
+
+        @Getter
+        @Builder
+        public static class TimedWeatherDTO {
+            private String datetime;
+            private WeatherResponseDTO weather;
+        }
+
+        @Getter @Builder
+        public static class TimedCongestionDTO {
+            private String datetime;
+            private PredictionResponseDTO prediction;
+        }
     }
 }

--- a/src/main/java/com/tave/weathertago/service/station/StationQueryService.java
+++ b/src/main/java/com/tave/weathertago/service/station/StationQueryService.java
@@ -13,7 +13,7 @@ public interface StationQueryService {
 
     List<StationResponseDTO.StationInfoDTO> getAllStationsInfo();
 
-
+    StationResponseDTO.StationStatusResponseDTO getStatus(Long stationId, LocalDateTime baseDatetime);
 }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146 

## 📝작업 내용

> 지정된 기준 시각부터 3일 뒤 00시까지의 날씨와 혼잡도 정보를 시간대별로 조회하는 api 구현