### PR TITLE
[Fix] 지하철 역 시간대별 상태 조회 api queryParameter 네이밍 변경

### DIFF
--- a/src/main/java/com/tave/weathertago/controller/CongestionTestController.java
+++ b/src/main/java/com/tave/weathertago/controller/CongestionTestController.java
@@ -5,6 +5,7 @@ import com.tave.weathertago.apiPayload.ApiResponse;
 import com.tave.weathertago.dto.prediction.PredictionResponseDTO;
 import com.tave.weathertago.dto.prediction.PredictionWithWeatherResponseDTO;
 import com.tave.weathertago.service.congestion.CongestionQueryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "테스트용", description = "테스트용임 프론트 사용 X 추후 삭제 예정")
 @RestController
 @RequestMapping("/api/congestion")
 @RequiredArgsConstructor

--- a/src/main/java/com/tave/weathertago/controller/WeatherTestController.java
+++ b/src/main/java/com/tave/weathertago/controller/WeatherTestController.java
@@ -4,6 +4,7 @@ package com.tave.weathertago.controller;
 import com.tave.weathertago.apiPayload.ApiResponse;
 import com.tave.weathertago.dto.weather.WeatherResponseDTO;
 import com.tave.weathertago.service.weather.WeatherQueryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 
+@Tag(name = "테스트용", description = "테스트용임 프론트 사용 X 추후 삭제 예정")
 @RestController
 @RequestMapping("/api/test/weather")
 @RequiredArgsConstructor

--- a/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
@@ -85,7 +85,7 @@ public class StationRestController {
             @RequestParam("stationId") Long stationId,
 
             @Parameter(description = "기준 시각 (yyyy-MM-ddTHH:mm:ss)")
-            @RequestParam("baseDatetime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDatetime
+            @RequestParam("time") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDatetime
     ) {
         return ApiResponse.onSuccess(
                 stationQueryService.getStatus(stationId, baseDatetime)

--- a/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
@@ -7,6 +7,7 @@ import com.tave.weathertago.infrastructure.csv.StationCsvImporter;
 import com.tave.weathertago.service.station.StationQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Tag(name = "Station", description = "지하철역 정보 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/station")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146 

## 📝작업 내용

> 일관성을 위해 baseTime -> time으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * `/status` API 엔드포인트에서 날짜·시간 쿼리 파라미터명이 `"baseDatetime"`에서 `"time"`으로 변경되었습니다. 이제 요청 시 `"time"` 파라미터를 사용해야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->