### PR TITLE
[Feat] 날씨 상태 status 로직 추가 및 DTO 역할 분리

### DIFF
--- a/src/main/java/com/tave/weathertago/converter/WeatherConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/WeatherConverter.java
@@ -19,7 +19,7 @@ public class WeatherConverter {
 
     private static String resolveStatus(int pty, int sky) {
         return switch (pty) {
-            case 1 -> "비";
+            case 1, 4 -> "비";
             case 2 -> "눈비";
             case 3 -> "눈";
             default -> resolveSkyStatus(sky);

--- a/src/main/java/com/tave/weathertago/converter/WeatherConverter.java
+++ b/src/main/java/com/tave/weathertago/converter/WeatherConverter.java
@@ -1,0 +1,35 @@
+package com.tave.weathertago.converter;
+
+import com.tave.weathertago.dto.weather.WeatherInternalDTO;
+import com.tave.weathertago.dto.weather.WeatherResponseDTO;
+
+public class WeatherConverter {
+
+    public static WeatherResponseDTO toResponseDTO(WeatherInternalDTO dto) {
+        return WeatherResponseDTO.builder()
+                .tmp(dto.getTmp())
+                .reh(dto.getReh())
+                .pcp(dto.getPcp())
+                .wsd(dto.getWsd())
+                .sno(dto.getSno())
+                .vec(dto.getVec())
+                .status(resolveStatus(dto.getPty(), dto.getSky()))
+                .build();
+    }
+
+    private static String resolveStatus(int pty, int sky) {
+        return switch (pty) {
+            case 1 -> "비";
+            case 2 -> "눈비";
+            case 3 -> "눈";
+            default -> resolveSkyStatus(sky);
+        };
+    }
+
+    private static String resolveSkyStatus(int sky) {
+        if (sky >= 0 && sky <= 5) return "맑음";
+        if (sky >= 6 && sky <= 8) return "구름많음";
+        if (sky >= 9 && sky <= 10) return "흐림";
+        return "정보 없음";
+    }
+}

--- a/src/main/java/com/tave/weathertago/dto/weather/WeatherInternalDTO.java
+++ b/src/main/java/com/tave/weathertago/dto/weather/WeatherInternalDTO.java
@@ -5,16 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class WeatherResponseDTO {
+public class WeatherInternalDTO implements Serializable {
     private double tmp;
     private double reh;
     private double pcp;
     private double wsd;
     private double sno;
     private double vec;
-    private String status;
+    private int sky;
+    private int pty;
 }

--- a/src/main/java/com/tave/weathertago/infrastructure/WeatherApiClient.java
+++ b/src/main/java/com/tave/weathertago/infrastructure/WeatherApiClient.java
@@ -5,7 +5,7 @@ import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
 import com.tave.weathertago.apiPayload.exception.handler.WeatherHandler;
 import com.tave.weathertago.domain.Station;
 import com.tave.weathertago.dto.weather.WeatherApiResponseDTO;
-import com.tave.weathertago.dto.weather.WeatherResponseDTO;
+import com.tave.weathertago.dto.weather.WeatherInternalDTO;
 import com.tave.weathertago.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +49,7 @@ public class WeatherApiClient {
     private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HHmm");
     private static final DateTimeFormatter DATETIME_KEY_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
-    public WeatherResponseDTO getAndCacheWeather(Long stationId, LocalDateTime datetime) {
+    public WeatherInternalDTO getAndCacheWeather(Long stationId, LocalDateTime datetime) {
         Station station = stationRepository.findById(stationId)
                 .orElseThrow(() -> new WeatherHandler(ErrorStatus.STATION_ID_NOT_FOUND));
 
@@ -58,12 +58,12 @@ public class WeatherApiClient {
 
         String responseBody = sendApiRequest(uri);
         WeatherApiResponseDTO apiResponse = parseWeatherResponse(responseBody);
-        Map<String, WeatherResponseDTO> cacheMap = processApiResponse(station, apiResponse);
+        Map<String, WeatherInternalDTO> cacheMap = processApiResponse(station, apiResponse);
 
         bulkSaveToRedis(cacheMap);
 
         String redisKey = makeRedisKey(station.getNx(), station.getNy(), datetime);
-        WeatherResponseDTO result = cacheMap.get(redisKey);
+        WeatherInternalDTO result = cacheMap.get(redisKey);
 
         // 정확히 일치하는 예보 시간이 없을 경우: 가장 가까운 예보 시간으로 fallback
         if (result == null && !cacheMap.isEmpty()) {
@@ -74,7 +74,7 @@ public class WeatherApiClient {
         return result;
     }
 
-    private WeatherResponseDTO getNearestForecast(Map<String, WeatherResponseDTO> cacheMap, Station station, LocalDateTime targetTime) {
+    private WeatherInternalDTO getNearestForecast(Map<String, WeatherInternalDTO> cacheMap, Station station, LocalDateTime targetTime) {
         return cacheMap.entrySet().stream()
                 .min(Comparator.comparing(entry -> {
                     String keyTime = entry.getKey().split(":")[3]; // yyyy-MM-dd'T'HH:mm:ss
@@ -130,7 +130,7 @@ public class WeatherApiClient {
         }
     }
 
-    private Map<String, WeatherResponseDTO> processApiResponse(Station station, WeatherApiResponseDTO apiResponse) {
+    private Map<String, WeatherInternalDTO> processApiResponse(Station station, WeatherApiResponseDTO apiResponse) {
         if (apiResponse == null ||
                 apiResponse.getResponse() == null ||
                 apiResponse.getResponse().getBody() == null ||
@@ -151,7 +151,7 @@ public class WeatherApiClient {
                     .put(item.getCategory(), item.getFcstValue());
         }
 
-        Map<String, WeatherResponseDTO> cacheMap = new HashMap<>();
+        Map<String, WeatherInternalDTO> cacheMap = new HashMap<>();
         LocalDateTime now = LocalDateTime.now();
 
         for (Map.Entry<String, Map<String, String>> entry : grouped.entrySet()) {
@@ -161,13 +161,15 @@ public class WeatherApiClient {
             if (fcstTime.isAfter(now.toLocalDate().plusDays(3).atTime(0, 0))) continue;
 
             Map<String, String> cat = entry.getValue();
-            WeatherResponseDTO dto = WeatherResponseDTO.builder()
+            WeatherInternalDTO dto = WeatherInternalDTO.builder()
                     .tmp(parse("TMP", cat.get("TMP")))
                     .reh(parse("REH", cat.get("REH")))
                     .pcp(parse("PCP", cat.get("PCP")))
                     .wsd(parse("WSD", cat.get("WSD")))
                     .sno(parse("SNO", cat.get("SNO")))
                     .vec(parse("VEC", cat.get("VEC")))
+                    .sky(parseInt(cat.get("SKY")))
+                    .pty(parseInt(cat.get("PTY")))
                     .build();
 
             String redisKey = makeRedisKey(station.getNx(), station.getNy(), fcstTime);
@@ -177,12 +179,12 @@ public class WeatherApiClient {
         return cacheMap;
     }
 
-    private void bulkSaveToRedis(Map<String, WeatherResponseDTO> dataMap) {
+    private void bulkSaveToRedis(Map<String, WeatherInternalDTO> dataMap) {
         RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
         RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
 
         redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            for (Map.Entry<String, WeatherResponseDTO> entry : dataMap.entrySet()) {
+            for (Map.Entry<String, WeatherInternalDTO> entry : dataMap.entrySet()) {
                 byte[] key = keySerializer.serialize(entry.getKey());
                 byte[] value = valueSerializer.serialize(entry.getValue());
                 connection.stringCommands().set(
@@ -229,14 +231,14 @@ public class WeatherApiClient {
         }
     }
 
-//    private int parseInt(String val) {
-//        if (val == null) return 0;
-//        try {
-//            return Integer.parseInt(val);
-//        } catch (NumberFormatException e) {
-//            return 0;
-//        }
-//    }
+    private int parseInt(String val) {
+        if (val == null) return 0;
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
 
     private String makeRedisKey(Integer nx, Integer ny, LocalDateTime time) {
         return "weather:" + nx + ":" + ny + ":" + time.format(DATETIME_KEY_FMT);

--- a/src/main/java/com/tave/weathertago/service/alarm/AlarmSendServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/alarm/AlarmSendServiceImpl.java
@@ -7,8 +7,6 @@ import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
 import com.tave.weathertago.apiPayload.exception.handler.AlarmHandler;
 import com.tave.weathertago.converter.AlarmConverter;
 import com.tave.weathertago.domain.Alarm;
-import com.tave.weathertago.domain.AlarmDay;
-import com.tave.weathertago.domain.AlarmPeriod;
 import com.tave.weathertago.dto.alarm.AlarmFcmMessageDto;
 import com.tave.weathertago.dto.prediction.PredictionResponseDTO;
 import com.tave.weathertago.dto.prediction.PredictionWithWeatherResponseDTO;
@@ -17,19 +15,14 @@ import com.tave.weathertago.repository.AlarmRepository;
 import com.tave.weathertago.repository.UserRepository;
 import com.tave.weathertago.service.congestion.CongestionQueryService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Set;
 
 @Service

--- a/src/main/java/com/tave/weathertago/service/weather/WeatherQueryServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/weather/WeatherQueryServiceImpl.java
@@ -2,7 +2,9 @@ package com.tave.weathertago.service.weather;
 
 import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
 import com.tave.weathertago.apiPayload.exception.handler.StationHandler;
+import com.tave.weathertago.converter.WeatherConverter;
 import com.tave.weathertago.domain.Station;
+import com.tave.weathertago.dto.weather.WeatherInternalDTO;
 import com.tave.weathertago.dto.weather.WeatherResponseDTO;
 import com.tave.weathertago.infrastructure.WeatherApiClient;
 import com.tave.weathertago.repository.StationRepository;
@@ -32,13 +34,14 @@ public class WeatherQueryServiceImpl implements WeatherQueryService {
         String key = makeWeatherRedisKey(station.getNx(), station.getNy(), datetime);
 
         Object cached = redisTemplate.opsForValue().get(key);
-        if (cached instanceof WeatherResponseDTO weather) {
+        if (cached instanceof WeatherInternalDTO internalDTO) {
             log.info("✅ 날씨 Redis 캐시 Hit: {}", key);
-            return weather;
+            return WeatherConverter.toResponseDTO(internalDTO);
         }
 
         log.info("날씨 Redis 캐시 Miss → 기상청 API 요청");
-        return weatherApiClient.getAndCacheWeather(stationId, datetime);
+        WeatherInternalDTO apiResult = weatherApiClient.getAndCacheWeather(stationId, datetime);
+        return WeatherConverter.toResponseDTO(apiResult);
     }
 
     private String makeWeatherRedisKey(Integer nx, Integer ny, LocalDateTime datetime) {

--- a/src/test/java/com/tave/weathertago/infrastructure/WeatherApiClientTest.java
+++ b/src/test/java/com/tave/weathertago/infrastructure/WeatherApiClientTest.java
@@ -1,16 +1,7 @@
 package com.tave.weathertago.infrastructure;
 
 import com.tave.weathertago.dto.weather.WeatherResponseDTO;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #32

## 📝작업 내용

> 날씨 응답용 DTO와 redis 저장용 DTO 분리
> 기상청 api에서 sky, pty 코드도 저장하도록 수정
> "맑음", "흐림" 등 날씨 요약 정보 status 필드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 새로운 내부 날씨 데이터 객체가 도입되어, 날씨 정보를 더욱 세분화하여 관리합니다.
  * 날씨 응답에 상태(status) 정보가 추가되어, 강수 형태와 하늘 상태에 따른 한글 상태값을 제공합니다.

* **버그 수정**
  * 불필요한 import 구문이 제거되어 코드가 정리되었습니다.

* **리팩터링**
  * 내부 데이터 처리 및 캐싱 로직이 개선되어, 내부 DTO와 응답 DTO 간의 변환 과정을 명확히 하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->