### PR TITLE
[Feat] 로그아웃, 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -24,6 +25,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
+
+    private static final List<String> EXCLUDED_PATHS = List.of(
+            "/api/auth/login",
+            "/api/auth/reissue"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return EXCLUDED_PATHS.contains(path);
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
@@ -120,6 +120,7 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody()
                 .getExpiration();
-        return expiration.getTime() - System.currentTimeMillis();
+        long remaining = expiration.getTime() - System.currentTimeMillis();
+        return Math.max(0, remaining);
     }
 }

--- a/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/tave/weathertago/config/security/jwt/JwtTokenProvider.java
@@ -111,4 +111,15 @@ public class JwtTokenProvider {
     public long getRefreshTokenExpiration() {
         return jwtProperties.getExpiration().getRefresh();
     }
+
+    // 토큰 남은 유효 시간 반환
+    public long getTokenRemainingTime(String token) {
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
 }

--- a/src/main/java/com/tave/weathertago/controller/auth/AuthController.java
+++ b/src/main/java/com/tave/weathertago/controller/auth/AuthController.java
@@ -1,11 +1,13 @@
-package com.tave.weathertago.controller;
+package com.tave.weathertago.controller.auth;
 
 import com.tave.weathertago.apiPayload.ApiResponse;
+import com.tave.weathertago.config.security.jwt.JwtTokenProvider;
 import com.tave.weathertago.dto.Auth.AuthRequestDTO;
 import com.tave.weathertago.dto.Auth.AuthResponseDTO;
 import com.tave.weathertago.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/login")
     @Operation(summary = "카카오 로그인", description = "카카오 accessToken으로 로그인/회원가입을 처리하고 JWT를 발급합니다.")
@@ -31,5 +34,13 @@ public class AuthController {
     @Operation(summary = "토큰 재발급", description = "refreshToken으로 accessToken을 재발급합니다.")
     public ApiResponse<AuthResponseDTO.ReissueResultDTO> reissue(@RequestBody @Valid AuthRequestDTO.ReissueRequest request) {
         return ApiResponse.onSuccess(authService.reissueToken(request));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "JWT를 블랙리스트 처리하고 리프레시 토큰을 만료시킵니다.")
+    public ApiResponse<Void> logout(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        authService.logout(accessToken);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/tave/weathertago/controller/user/UserRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/user/UserRestController.java
@@ -1,11 +1,15 @@
-package com.tave.weathertago.controller;
+package com.tave.weathertago.controller.user;
 
 import com.tave.weathertago.apiPayload.ApiResponse;
+import com.tave.weathertago.config.security.jwt.JwtTokenProvider;
 import com.tave.weathertago.dto.user.UserInfoResponseDTO;
+import com.tave.weathertago.service.user.UserCommandService;
 import com.tave.weathertago.service.user.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,10 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserRestController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 닉네임과 이메일을 반환합니다.")
     public ApiResponse<UserInfoResponseDTO> getMyInfo() {
         return ApiResponse.onSuccess(userQueryService.getMyInfo());
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴", description = "회원 정보를 삭제하고 토큰을 무효화합니다.")
+    public ApiResponse<Void> withdraw(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        userCommandService.deleteUser(accessToken);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/tave/weathertago/domain/User.java
+++ b/src/main/java/com/tave/weathertago/domain/User.java
@@ -4,6 +4,9 @@ import com.tave.weathertago.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -23,4 +26,10 @@ public class User extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String email;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Favorite favorite;
+
+    @OneToMany(mappedBy = "userId", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Alarm> alarms = new ArrayList<>();
 }

--- a/src/main/java/com/tave/weathertago/service/auth/AuthService.java
+++ b/src/main/java/com/tave/weathertago/service/auth/AuthService.java
@@ -6,4 +6,5 @@ import com.tave.weathertago.dto.Auth.AuthResponseDTO;
 public interface AuthService {
     AuthResponseDTO.LoginResultDTO kakaoLogin(String kakaoAccessToken);
     AuthResponseDTO.ReissueResultDTO reissueToken(AuthRequestDTO.ReissueRequest request);
+    void logout(String accessToken);
 }

--- a/src/main/java/com/tave/weathertago/service/user/UserCommandService.java
+++ b/src/main/java/com/tave/weathertago/service/user/UserCommandService.java
@@ -1,0 +1,5 @@
+package com.tave.weathertago.service.user;
+
+public interface UserCommandService {
+    void deleteUser(String accessToken);
+}

--- a/src/main/java/com/tave/weathertago/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/user/UserCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package com.tave.weathertago.service.user;
+
+import com.tave.weathertago.apiPayload.code.status.ErrorStatus;
+import com.tave.weathertago.apiPayload.exception.handler.UserHandler;
+import com.tave.weathertago.config.security.jwt.JwtTokenProvider;
+import com.tave.weathertago.domain.User;
+import com.tave.weathertago.repository.AlarmRepository;
+import com.tave.weathertago.repository.FavoriteRepository;
+import com.tave.weathertago.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final FavoriteRepository favoriteRepository;
+    private final AlarmRepository alarmRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    @Transactional
+    public void deleteUser(String accessToken) {
+        jwtTokenProvider.validateToken(accessToken);
+        String kakaoId = jwtTokenProvider.getKakaoId(accessToken);
+
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 사용자 삭제
+        userRepository.delete(user);
+
+        // 토큰 삭제
+        redisTemplate.delete("refresh:" + user.getId());
+        String blacklistKey = "blacklist:" + accessToken;
+        long remaining = jwtTokenProvider.getTokenRemainingTime(accessToken);
+        redisTemplate.opsForValue().set(blacklistKey, "withdrawn", remaining, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #80 

## 📝작업 내용

> 인증이 필요 없는 API에서 잘못된 토큰이 들어와도 예외 발생 없이 무시하도록 처리
> 로그아웃 api 구현 -> refreshToken 삭제 및 accessToken 블랙리스트 처리
> 회원탈퇴 api 구현 -> 회원 탈퇴 시 관련 연관 엔티티(Alarm 등)를 cascade = REMOVE로 설정하여 같이 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 API가 추가되어, 사용자가 로그아웃 시 토큰이 즉시 무효화됩니다.
  * 회원 탈퇴 API가 추가되어, 사용자가 직접 계정을 삭제할 수 있습니다.

* **기능 개선**
  * 인증 필터에서 로그인 및 토큰 재발급 경로는 인증 없이 접근할 수 있도록 제외 처리되었습니다.
  * 회원 탈퇴 시, 관련 즐겨찾기 및 알림 정보도 함께 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->