### PR TITLE
[Fix] 지하철 역 시간대별 상태 조회 api를 무조건 현재 시간부터 조회하도록 수정

### DIFF
--- a/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
+++ b/src/main/java/com/tave/weathertago/controller/stationController/StationRestController.java
@@ -80,17 +80,14 @@ public class StationRestController {
         return ApiResponse.onSuccess(result);
     }
 
-    @Operation(summary = "지하철 역 시간대별 상태 조회", description = "지정된 기준 시각부터 3일 뒤 00시까지의 날씨와 혼잡도 정보를 시간대별로 조회합니다.")
+    @Operation(summary = "지하철 역 시간대별 상태 조회", description = "현재 시각부터 3일 뒤 00시까지의 날씨와 혼잡도 정보를 시간대별로 조회합니다.")
     @GetMapping("/status")
     public ApiResponse<StationResponseDTO.StationStatusResponseDTO> getStatus(
             @Parameter(description = "조회할 역의 ID")
-            @RequestParam("stationId") Long stationId,
-
-            @Parameter(description = "기준 시각 (yyyy-MM-ddTHH:mm:ss)")
-            @RequestParam("time") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime baseDatetime
+            @RequestParam("stationId") Long stationId
     ) {
         return ApiResponse.onSuccess(
-                stationQueryService.getStatus(stationId, baseDatetime)
+                stationQueryService.getStatus(stationId)
         );
     }
 

--- a/src/main/java/com/tave/weathertago/service/station/StationQueryService.java
+++ b/src/main/java/com/tave/weathertago/service/station/StationQueryService.java
@@ -13,7 +13,7 @@ public interface StationQueryService {
 
     List<StationResponseDTO.StationInfoDTO> getAllStationsInfo();
 
-    StationResponseDTO.StationStatusResponseDTO getStatus(Long stationId, LocalDateTime baseDatetime);
+    StationResponseDTO.StationStatusResponseDTO getStatus(Long stationId);
 }
 
 

--- a/src/main/java/com/tave/weathertago/service/station/StationQueryServiceImpl.java
+++ b/src/main/java/com/tave/weathertago/service/station/StationQueryServiceImpl.java
@@ -148,14 +148,14 @@ public class StationQueryServiceImpl implements StationQueryService {
     */
 
     @Override
-    public StationResponseDTO.StationStatusResponseDTO getStatus(Long stationId, LocalDateTime baseDatetime) {
+    public StationResponseDTO.StationStatusResponseDTO getStatus(Long stationId) {
         Station station = stationRepository.findById(stationId)
                 .orElseThrow(() -> new StationHandler(ErrorStatus.STATION_ID_NOT_FOUND));
 
         List<StationResponseDTO.StationStatusResponseDTO.TimedWeatherDTO> weathers = new ArrayList<>();
         List<StationResponseDTO.StationStatusResponseDTO.TimedCongestionDTO> congestions = new ArrayList<>();
 
-        LocalDateTime now = baseDatetime;
+        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0).plusHours(1);
         LocalDateTime end = now.toLocalDate().plusDays(3).atTime(0, 0);
 
         for (LocalDateTime dt = now; !dt.isAfter(end); dt = dt.plusHours(1)) {


### PR DESCRIPTION
## 📝작업 내용

> 기존에는 클라이언트로부터 직접 기준 시간을 입력 받았었는데, 오류의 가능성을 줄이기 위해 무조건 현재 시간부터 3일 뒤까지의 날씨와 혼잡도를 제공하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 정류장 상태 조회 시 기준 시간이 더 이상 필요하지 않으며, 현재 시각을 기준으로 3일 후 자정까지의 날씨와 혼잡도 데이터를 제공합니다.

* **문서**
  * API 문서에서 기준 시간 관련 설명이 "지정한 기준 시간"에서 "현재 시간"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->