### PR TITLE
[fix] 알림 스케쥴러 기능 수정

### DIFF
--- a/src/main/java/com/tave/weathertago/repository/AlarmRepository.java
+++ b/src/main/java/com/tave/weathertago/repository/AlarmRepository.java
@@ -4,6 +4,8 @@ import com.tave.weathertago.domain.*;
 import com.tave.weathertago.domain.enums.AlarmDay;
 import com.tave.weathertago.domain.enums.AlarmPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -14,5 +16,11 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Optional<Alarm> findByAlarmId(Long alarmId);
 
-    List<Alarm> findAllByAlarmPeriodAndAlarmDayAndAlarmTime(AlarmPeriod alarmPeriod, AlarmDay alarmDay, LocalTime alarmTime);
+    @Query("SELECT a FROM Alarm a JOIN FETCH a.stationId JOIN FETCH a.userId " +
+            "WHERE a.alarmPeriod = :alarmPeriod AND a.alarmDay = :alarmDay AND a.alarmTime = :alarmTime")
+    List<Alarm> findAllWithStationAndUserByAlarmPeriodAndAlarmDayAndAlarmTime(
+            @Param("alarmPeriod") AlarmPeriod alarmPeriod,
+            @Param("alarmDay") AlarmDay alarmDay,
+            @Param("alarmTime") LocalTime alarmTime);
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39 

## 📝문제 상황

로그를 보면 Hibernate Lazy Loading 관련 문제가 발생하고 있습니다. 에러 메시지 "Could not initialize proxy [com.tave.weathertago.domain.Station#2] - no session"는 JPA 엔티티의 지연 로딩(Lazy Loading)된 프록시 객체에 접근할 때 Hibernate 세션이 없어서 발생하는 전형적인 오류입니다.

## 📝근본 원인
스케줄링 컨텍스트에서의 세션 문제:

@Scheduled 메서드에서 실행되는 작업은 별도의 스레드에서 동작
sendAlarm() 메서드가 @Transactional이지만, 스케줄링 컨텍스트에서 호출될 때 세션 관리에 문제 발생
alarm.getStationId()에 접근할 때 Station 엔티티가 지연 로딩되어 있어 프록시 상태로 존재
트랜잭션이 제대로 관리되지 않아 세션이 닫힌 상태에서 프록시 객체에 접근하려 할 때 오류 발생

해결 방법
1. 즉시 해결 방법: Fetch Join 사용
AlarmRepository에 Station을 즉시 로딩하는 메서드 추가

2. 서비스 메서드 수정
AlarmSendServiceImpl의 스케줄링 메서드들을 수정:

3. 추가 개선사항: 트랜잭션 전파 설정
sendAlarmBatch 메서드에 트랜잭션 애노테이션 추가:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알람 발송 시 관련된 역 및 사용자 정보가 함께 조회되어 알람 데이터의 정확성이 향상되었습니다.

* **기타**
  * 알람 일괄 발송 작업이 독립적인 트랜잭션으로 처리되어 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->